### PR TITLE
Update GitHub Actions to use Node.js 20

### DIFF
--- a/.github/workflows/deploy-utfprtd.yml
+++ b/.github/workflows/deploy-utfprtd.yml
@@ -16,9 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Python 3.10
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.github/workflows/deploy-utfprtd.yml
+++ b/.github/workflows/deploy-utfprtd.yml
@@ -1,68 +1,66 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
-# There is a section specific for UTFPR-TD VM server. 
+# There is a section specific for UTFPR-TD VM server.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: AVACPQ Python application test and deploy workflow
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi    
-    #edit: logs in docker hub, (build and) publish to the private registry (allowing deploy step)   
-    - name: publish-docker-image  
-      uses: mr-smithers-excellent/docker-build-push@v6
-      with:
+      - name: Set up Python 3.10
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      #edit: logs in docker hub, (build and) publish to the private registry (allowing deploy step)
+      - name: publish-docker-image
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
           image: aagiron/avacpq
           registry: docker.io
-          addLatest: true 
+          addLatest: true
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     #- name: Test with pytest
     #  run: |
     #    pytest
-  
+
   #https://github.com/marketplace/actions/remote-ssh-commands
-  deploy-via-ssh: #deploy job to UTFPRTD server (download docker image and build it)    
-      runs-on: ubuntu-latest
-      needs: build
-      steps:
-        - name: deploy via OPENSSH Private Key
-          uses: fifsky/ssh-action@master
-          with:          #install docker in Alpine; download from docker registry; build and run
-            command: |
-              apk add docker
-              service docker start              
-              echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-              docker run -d -p 8050:8050 aagiron/avacpq:latest
-              docker logout
-            host: ${{ secrets.UTFPRTD_HOST }}
-            user: root
-            #port: 443
-            key: ${{ secrets.UTFPRTD_PRIVATE_KEY}}
-            args: "-tt -v"
+  deploy-via-ssh: #deploy job to UTFPRTD server (download docker image and build it)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: deploy via OPENSSH Private Key
+        uses: fifsky/ssh-action@master
+        with: #install docker in Alpine; download from docker registry; build and run
+          command: |
+            apk add docker
+            service docker start
+            echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+            docker run -d -p 8050:8050 aagiron/avacpq:latest
+            docker logout
+          host: ${{ secrets.UTFPRTD_HOST }}
+          user: root
+          #port: 443
+          key: ${{ secrets.UTFPRTD_PRIVATE_KEY}}
+          args: "-tt -v"


### PR DESCRIPTION
As discussed in [Issue #14](#14), we are receiving a warning about the deprecated Node.js 16 version in our GitHub Actions workflows. To resolve this, I've updated the relevant actions to ensure compatibility with Node.js 20.

### Changes Made

- Updated `actions/checkout` from `v3` to `v4`
- Updated `actions/setup-python` from `v3` to `v5`
- Fixed various spacing and newline issues in the workflow file

### References

- [GitHub Actions: Transitioning from Node.js 16 to Node.js 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
- [GitHub Actions: setup-python](https://github.com/actions/setup-python)
- [GitHub Actions: checkout](https://github.com/actions/checkout)

By addressing this warning, we ensure our CI/CD pipeline remains up-to-date and avoids potential disruptions due to deprecated Node.js versions. Please review the changes and let me know if any further adjustments are needed.

Closes #14